### PR TITLE
get rid of hard coded urls

### DIFF
--- a/TODO
+++ b/TODO
@@ -1,7 +1,2 @@
-package revalidator as an AMD module
-unit tests
-break down spec.js
-URL providers and cred providers
-real logger
-remove hard coded usernames and urls
-test coverage checking
+cred providers
+remove hard coded usernames

--- a/bower.json
+++ b/bower.json
@@ -4,7 +4,7 @@
   "homepage" : "https://github.com/kryptnostic/soteria",
   "license"  : "MIT",
   "private"  : true,
-  "authors": [
+  "authors"  : [
     "Nick Hewitt <nick@kryptnostic.com>",
     "Ryan Buckheit <ryan@kryptnostic.com>"
   ],
@@ -14,12 +14,13 @@
   ],
   "dependencies": {
     "bluebird"   : "2.9.32",
-    "require-cs" : "0.5.0",
-    "requirejs"  : "2.1.18",
-    "pako"       : "0.2.6",
     "Cookies"    : "1.2.1",
+    "forge"      : "0.6.21",
     "jquery"     : "2.1.3",
     "lodash"     : "3.10.0",
-    "forge"      : "0.6.21"
+    "loglevel"   : "~1.3.1",
+    "pako"       : "0.2.6",
+    "require-cs" : "0.5.0",
+    "requirejs"  : "2.1.18"
   }
 }

--- a/build.js
+++ b/build.js
@@ -13,7 +13,8 @@
       'lodash'      : '../../bower_components/lodash/lodash',
       'pako'        : '../../bower_components/pako/dist/pako',
       'require'     : '../../bower_components/requirejs/require',
-      'revalidator' : '../../node_modules/revalidator/lib/revalidator',
+      'loglevel'    : '../../bower_components/loglevel/dist/loglevel',
+      'revalidator' : '../../node_modules/revalidator/lib/revalidator'
     },
     packages : [
       {

--- a/compile-exports.rb
+++ b/compile-exports.rb
@@ -6,13 +6,14 @@
 #
 
 JS_LIB_EXPORTS = [
-  'require',
+  'bluebird',
   'forge',
-  'pako',
   'jquery',
   'lodash',
-  'revalidator',
-  'bluebird'
+  'loglevel',
+  'pako',
+  'require',
+  'revalidator'
 ]
 
 EXPORT_FILE_PATH = 'js/src/soteria.coffee'

--- a/js/src/crypto/CryptoServiceLoader.coffee
+++ b/js/src/crypto/CryptoServiceLoader.coffee
@@ -67,7 +67,7 @@ define 'soteria.crypto-service-loader', [
       ).then (rsaCryptoService, serializedCryptoService) =>
 
         if !serializedCryptoService
-          logger.log('no cryptoService exists for this object. creating one on-the-fly', {id})
+          logger.info('no cryptoService exists for this object. creating one on-the-fly', {id})
           cryptoService = new AesCryptoService( Cypher.AES_CTR_128 )
           @setObjectCryptoService( id, cryptoService )
           deferred.resolve(cryptoService)

--- a/js/src/http/DirectoryApi.coffee
+++ b/js/src/http/DirectoryApi.coffee
@@ -2,20 +2,22 @@ define 'soteria.directory-api', [
   'require'
   'jquery'
   'forge'
-  'soteria.security-utils'
-  'soteria.public-key-envelope'
+  'soteria.configuration'
   'soteria.logger'
+  'soteria.public-key-envelope'
+  'soteria.security-utils'
 ], (require) ->
 
+  Forge              = require 'forge'
   jquery             = require 'jquery'
   SecurityUtils      = require 'soteria.security-utils'
   Logger             = require 'soteria.logger'
   PublicKeyEnvelope  = require 'soteria.public-key-envelope'
-  Forge              = require 'forge'
+  Configuration      = require 'soteria.configuration'
 
-  CRYPTO_SERVICE_URL = 'http://localhost:8081/v1/directory/object'
-  PRIVATE_KEY_URL    = 'http://localhost:8081/v1/directory/private'
-  PUBLIC_KEY_URL     = 'http://localhost:8081/v1/directory/public'
+  cryptoServiceUrl   = -> Configuration.get('servicesUrl') + '/directory/object'
+  privateKeyUrl      = -> Configuration.get('servicesUrl') + '/directory/private'
+  publicKeyUrl       = -> Configuration.get('servicesUrl') + '/directory/public'
 
   logger             = Logger.get('DirectoryApi')
 
@@ -38,7 +40,7 @@ define 'soteria.directory-api', [
       validateId(objectId)
 
       return jquery.ajax(SecurityUtils.wrapRequest({
-        url  : CRYPTO_SERVICE_URL + '/' + objectId
+        url  : cryptoServiceUrl() + '/' + objectId
         type : 'GET'
       }))
       .then (response) ->
@@ -52,7 +54,7 @@ define 'soteria.directory-api', [
       validateCrytpoServiceByteBuffer(byteBufferStr)
 
       return jquery.ajax(SecurityUtils.wrapRequest({
-        url         : CRYPTO_SERVICE_URL + '/' + objectId
+        url         : cryptoServiceUrl() + '/' + objectId
         type        : 'POST'
         data        : JSON.stringify({data: btoa(byteBufferStr)})
         contentType : 'application/json'
@@ -64,7 +66,7 @@ define 'soteria.directory-api', [
     # gets encrypted RSA private keys for the current user
     getRsaKeys: ->
       return jquery.ajax(SecurityUtils.wrapRequest({
-        url  : PRIVATE_KEY_URL
+        url  : privateKeyUrl()
         type : 'GET'
       }))
       .then (response) ->
@@ -74,7 +76,7 @@ define 'soteria.directory-api', [
     # gets the public key of a user in the same realm as the caller.
     getPublicKey: (username) ->
       return jquery.ajax(SecurityUtils.wrapRequest({
-        url  : PUBLIC_KEY_URL + '/' + username
+        url  : publicKeyUrl() + '/' + username
         type : 'GET'
       }))
       .then (response) ->

--- a/js/src/http/ObjectApi.coffee
+++ b/js/src/http/ObjectApi.coffee
@@ -1,18 +1,19 @@
 define 'soteria.object-api', [
   'require'
   'jquery'
-  'soteria.security-utils'
+  'soteria.configuration'
   'soteria.kryptnostic-object'
   'soteria.logger'
+  'soteria.security-utils'
 ], (require) ->
 
   jquery            = require 'jquery'
   SecurityUtils     = require 'soteria.security-utils'
   KryptnosticObject = require 'soteria.kryptnostic-object'
   Logger            = require 'soteria.logger'
+  Config            = require 'soteria.configuration'
 
-  OBJECT_URL        = 'http://localhost:8081/v1/object'
-  TYPE_PATH         = '/type'
+  objectUrl         = -> Config.get('servicesUrl') + '/object'
 
   logger            = Logger.get('ObjectApi')
 
@@ -32,7 +33,7 @@ define 'soteria.object-api', [
     # get all object ids accessible to the user
     getObjectIds : ->
       jquery.ajax(SecurityUtils.wrapRequest({
-        url  : OBJECT_URL
+        url  : objectUrl()
         type : 'GET'
       }))
       .then (response) ->
@@ -43,7 +44,7 @@ define 'soteria.object-api', [
       validateId(id)
 
       jquery.ajax(SecurityUtils.wrapRequest({
-        url  : OBJECT_URL + '/' + id
+        url  : objectUrl() + '/' + id
         type : 'GET'
       }))
       .then (data) ->
@@ -54,7 +55,7 @@ define 'soteria.object-api', [
       validateType(type)
 
       jquery.ajax(SecurityUtils.wrapRequest({
-        url  : OBJECT_URL + TYPE_PATH + '/' + type
+        url  : objectUrl() + '/type/' + type
         type : 'GET'
       }))
       .then (response) ->
@@ -65,7 +66,7 @@ define 'soteria.object-api', [
       pendingRequest.validate()
 
       jquery.ajax(SecurityUtils.wrapRequest({
-        url         : OBJECT_URL + '/'
+        url         : objectUrl() + '/'
         type        : 'PUT'
         contentType : 'application/json'
         data        : JSON.stringify(pendingRequest)
@@ -79,7 +80,7 @@ define 'soteria.object-api', [
       validateId(id)
 
       jquery.ajax(SecurityUtils.wrapRequest({
-        url  : OBJECT_URL + '/' + id
+        url  : objectUrl() + '/' + id
         type : 'PUT'
       }))
       .then (response) ->
@@ -91,7 +92,7 @@ define 'soteria.object-api', [
       validateId(id)
 
       jquery.ajax(SecurityUtils.wrapRequest({
-        url         : OBJECT_URL + '/' + id
+        url         : objectUrl() + '/' + id
         type        : 'POST'
         contentType : 'application/json'
         data        : JSON.stringify(encryptableBlock)

--- a/js/src/http/SharingApi.coffee
+++ b/js/src/http/SharingApi.coffee
@@ -1,6 +1,7 @@
 define 'soteria.sharing-api', [
   'require'
   'jquery'
+  'soteria.configuration'
   'soteria.security-utils'
   'soteria.logger'
 ], (require) ->
@@ -8,8 +9,10 @@ define 'soteria.sharing-api', [
   jquery            = require 'jquery'
   SecurityUtils     = require 'soteria.security-utils'
   Logger            = require 'soteria.logger'
+  Config            = require 'soteria.configuration'
 
-  SHARING_URL       = 'http://localhost:8081/v1/share'
+  sharingUrl        = -> Config.get('servicesUrl') + '/share'
+
   TYPE_PATH         = '/type'
   SHARE_PATH        = '/share'
   REVOKE_PATH       = '/revoke'
@@ -27,7 +30,7 @@ define 'soteria.sharing-api', [
     # get all incoming shares
     getIncomingShares : ->
       jquery.ajax(SecurityUtils.wrapRequest({
-        url  : SHARING_URL + OBJECT_PATH
+        url  : sharingUrl() + OBJECT_PATH
         type : 'GET'
       }))
       .then (data) ->
@@ -38,7 +41,7 @@ define 'soteria.sharing-api', [
       sharingRequest.validate()
 
       jquery.ajax(SecurityUtils.wrapRequest({
-        url         : SHARING_URL + OBJECT_PATH + SHARE_PATH
+        url         : sharingUrl() + OBJECT_PATH + SHARE_PATH
         type        : 'POST'
         contentType : 'application/json'
         data        : JSON.stringify(sharingRequest)
@@ -52,7 +55,7 @@ define 'soteria.sharing-api', [
       revocationRequest.validate()
 
       jquery.ajax(SecurityUtils.wrapRequest({
-        url         : SHARING_URL + OBJECT_PATH + REVOKE_PATH
+        url         : sharingUrl() + OBJECT_PATH + REVOKE_PATH
         type        : 'POST'
         contentType : 'application/json'
         data        : JSON.stringify(revocationRequest)
@@ -66,7 +69,7 @@ define 'soteria.sharing-api', [
       keyRegistrationRequest.validate()
 
       jquery.ajax(SecurityUtils.wrapRequest({
-        url         : SHARING_URL + KEYS_PATH
+        url         : sharingUrl() + KEYS_PATH
         type        : 'POST'
         contentType : 'application/json'
         data        : JSON.stringify(keyRegistrationRequest)

--- a/js/src/model/object/ObjectMetadata.coffee
+++ b/js/src/model/object/ObjectMetadata.coffee
@@ -30,7 +30,7 @@ define 'soteria.object-metadata', [
   class ObjectMetadata
 
     constructor : (opts) ->
-      _.extend(this, opts, getDefaultOpts())
+      _.extend(this, getDefaultOpts(), opts)
       @validate()
 
     validate : =>

--- a/js/src/model/request/PendingObjectRequest.coffee
+++ b/js/src/model/request/PendingObjectRequest.coffee
@@ -18,7 +18,7 @@ define 'soteria.pending-object-request', [
   class PendingObjectRequest
 
     constructor : (opts) ->
-      _.extend(this, opts, DEFAULT_OPTS)
+      _.extend(this, DEFAULT_OPTS, opts)
       @validate()
 
     validate : () ->

--- a/js/src/model/request/SharingRequest.coffee
+++ b/js/src/model/request/SharingRequest.coffee
@@ -18,7 +18,7 @@ define 'soteria.sharing-request', [
   class SharingRequest
 
     constructor : (opts) ->
-      _.extend(this, opts, DEFAULT_OPTS)
+      _.extend(this, DEFAULT_OPTS, opts)
       @validate()
 
     validate : () ->

--- a/js/src/model/request/StorageRequest.coffee
+++ b/js/src/model/request/StorageRequest.coffee
@@ -18,7 +18,7 @@ define 'soteria.storage-request', [
   class StorageRequest
 
     constructor: (opts) ->
-      _.extend(this, opts, DEFAULT_OPTS)
+      _.extend(this, DEFAULT_OPTS, opts)
       @validate()
 
     validate : ->

--- a/js/src/service/ConfigurationService.coffee
+++ b/js/src/service/ConfigurationService.coffee
@@ -1,0 +1,31 @@
+define 'soteria.configuration', [
+  'require'
+  'lodash'
+  'soteria.logger'
+], (require) ->
+
+  log = require 'soteria.logger'
+
+  DEFAULTS = {
+    servicesUrl : 'http://localhost:8081/v1'
+  }
+
+  #
+  # Stores global Soteria configuration.
+  # Author: rbuckheit
+  #
+
+  class ConfigurationService
+
+    @config : _.cloneDeep(DEFAULTS)
+
+    @set : (opts) ->
+      _.extend(ConfigurationService.config, opts)
+
+    @get : (key) ->
+      if key?
+        return ConfigurationService.config[key]
+      else
+        return ConfigurationService.config
+
+  return ConfigurationService

--- a/js/src/util/Logger.coffee
+++ b/js/src/util/Logger.coffee
@@ -1,7 +1,17 @@
-define 'soteria.logger', [], (require) ->
+define 'soteria.logger', [
+  'require'
+  'loglevel'
+], (require) ->
+
+  # log configuration
+  # =================
+
+  log     = require 'loglevel'
+  PERSIST = true
+  log.setLevel('trace', PERSIST)
 
   #
-  # Logger which prevents log calls to Console in IE.
+  # Proxy logger which appends module names before logging.
   # Author: rbuckheit
   #
   class Logger
@@ -11,24 +21,24 @@ define 'soteria.logger', [], (require) ->
 
     constructor : (@moduleName) ->
 
-    log : (message, args...) ->
+    trace : (message, args...) ->
       args = args.map(JSON.stringify)
-      window.console && console.log("[#{@moduleName}] #{message} #{args}")
+      log.trace("[#{@moduleName}] #{message} #{args}")
 
     info : (message, args...) ->
       args = args.map(JSON.stringify)
-      window.console && console.info("[#{@moduleName}] #{message} #{args}")
+      log.info("[#{@moduleName}] #{message} #{args}")
 
     warn : (message, args...) ->
       args = args.map(JSON.stringify)
-      window.console && console.warn("[#{@moduleName}] #{message} #{args}")
+      log.warn("[#{@moduleName}] #{message} #{args}")
 
     error : (message, args...) ->
       args = args.map(JSON.stringify)
-      window.console && console.error("[#{@moduleName}] #{message} #{args}")
+      log.error("[#{@moduleName}] #{message} #{args}")
 
     debug: (message, args...) ->
       args = args.map(JSON.stringify)
-      window.console && console.debug("[#{@moduleName}] #{message} #{args}")
+      log.debug("[#{@moduleName}] #{message} #{args}")
 
   return Logger

--- a/js/test/crypto/AbstractCryptoService-test.coffee
+++ b/js/test/crypto/AbstractCryptoService-test.coffee
@@ -3,24 +3,27 @@ define [
   'soteria.abstract-crypto-service'
 ], (require) ->
 
-  AbstractCryptoService = require('soteria.abstract-crypto-service')
+  AbstractCryptoService = require 'soteria.abstract-crypto-service'
 
-  PASSWORD              = 'crom'
+  PASSWORD = 'crom'
 
   describe 'AbstractCryptoService', ->
 
     cryptoService = new AbstractCryptoService({ algorithm: 'AES', mode: 'CTR' })
 
     it 'should decrypt known-good values correctly', ->
-      decrypted = cryptoService.decrypt(atob("5wb/Vhk7dmM6jvCgC1Lltg=="),
-        atob("ewcVcNXbhKK463r41DFS2g=="),
-        atob("6veqEBl0TNxneQfnfpLbeRey5Yfe4oIKOqrepHn5vac="))
+      ciphertext = atob("5wb/Vhk7dmM6jvCgC1Lltg==")
+      key        = atob("6veqEBl0TNxneQfnfpLbeRey5Yfe4oIKOqrepHn5vac=")
+      iv         = atob("ewcVcNXbhKK463r41DFS2g==")
+      decrypted  = cryptoService.decrypt(ciphertext, iv, key)
+
       expect(decrypted).toBe("¢búð)lÚèKwz'öOXfþP¦ã¾þlTíMY")
 
     it 'should be able to decrypt what it encrypts', ->
       plaintext = "may the force be with you"
-      key = "5wb/Vhk7dmM6jvCgC1Lltg=="
-      iv = "ewcVcNXbhKK463r41DFS2g=="
+      key       = "5wb/Vhk7dmM6jvCgC1Lltg=="
+      iv        = "ewcVcNXbhKK463r41DFS2g=="
       encrypted = cryptoService.encrypt(key, iv, plaintext)
       decrypted = cryptoService.decrypt(key, iv, encrypted)
+
       expect(decrypted).toBe(plaintext)

--- a/js/test/service/ConfigurationService-test.coffee
+++ b/js/test/service/ConfigurationService-test.coffee
@@ -1,0 +1,33 @@
+define [
+  'require'
+  'soteria.configuration'
+], (require) ->
+
+  ConfigurationService = require 'soteria.configuration'
+
+  OVERRIDE_URL = 'http://localhost:9000/v1'
+  DEFAULT_URL  = 'http://localhost:8081/v1'
+
+  describe 'ConfigurationService', ->
+
+    describe 'initialization', ->
+
+      it 'should initialize with a default services URL of localhost', ->
+        expect(ConfigurationService.get('servicesUrl')).toBeDefined()
+        expect(ConfigurationService.get('servicesUrl')).toBe(DEFAULT_URL)
+
+    describe '#get', ->
+
+      it 'should fetch whole config object if no key', ->
+        ConfigurationService.set({servicesUrl : OVERRIDE_URL})
+        expect(ConfigurationService.get()).toEqual({ servicesUrl : OVERRIDE_URL })
+
+      it 'should fetch a single key if specified', ->
+        ConfigurationService.set({someKey: 'someValue'})
+        expect(ConfigurationService.get('someKey')).toBe('someValue')
+
+    describe '#set', ->
+
+      it 'should overwrite a default', ->
+        ConfigurationService.set({servicesUrl : 'http://localhost:9000/v1'})
+        expect(ConfigurationService.get('servicesUrl')).toBe('http://localhost:9000/v1')

--- a/test.sh
+++ b/test.sh
@@ -15,12 +15,12 @@ find js -name *.coffee | xargs ./node_modules/coffeelint/bin/coffeelint;
 # commit hooks
 # ============
 echo "running commit hooks..."
-./commit-hooks.rb
+./commit-hooks.rb;
 
 # r.js build
 # ==========
 echo "building soteria.js...";
-./build.sh --fast;
+./build.sh;
 
 # karma tests
 # ===========


### PR DESCRIPTION
1. set up a configuration object used to store url locations and other client configuration data.
2. get rid of hard-coded urls in favor of asking the config for the kryptnostic-services URL
3. sets up `loglevel` (a legit logging library) instead of `console.log`
